### PR TITLE
Add set-based sections to show tracks

### DIFF
--- a/mobile/src/main/java/com/bayapps/android/robophish/model/MusicProvider.kt
+++ b/mobile/src/main/java/com/bayapps/android/robophish/model/MusicProvider.kt
@@ -1,6 +1,7 @@
 package com.bayapps.android.robophish.model
 
 import android.content.Context
+import android.os.Bundle
 import androidx.media3.common.MediaItem
 import androidx.media3.common.MediaMetadata
 import com.bayapps.android.robophish.R
@@ -120,6 +121,11 @@ class MusicProvider(
             showId
         )
 
+        val extras = Bundle().apply {
+            set?.let { putString(EXTRA_TRACK_SET, it) }
+            setName?.let { putString(EXTRA_TRACK_SET_NAME, it) }
+        }
+
         val metadata = MediaMetadata.Builder()
             .setTitle(title)
             .setSubtitle(durationText)
@@ -129,6 +135,7 @@ class MusicProvider(
             .setArtworkUri(artUrl.let { android.net.Uri.parse(it) })
             .setIsBrowsable(false)
             .setIsPlayable(true)
+            .setExtras(extras.takeIf { it.size() > 0 })
             .build()
 
         return MediaItem.Builder()
@@ -143,5 +150,10 @@ class MusicProvider(
         val seconds = TimeUnit.MILLISECONDS.toSeconds(durationMs) -
             TimeUnit.MINUTES.toSeconds(minutes)
         return String.format("%d:%02d", minutes, seconds)
+    }
+
+    companion object {
+        const val EXTRA_TRACK_SET = "robophish.track.set"
+        const val EXTRA_TRACK_SET_NAME = "robophish.track.set_name"
     }
 }

--- a/mobile/src/main/java/com/bayapps/android/robophish/model/MusicProviderSource.kt
+++ b/mobile/src/main/java/com/bayapps/android/robophish/model/MusicProviderSource.kt
@@ -41,5 +41,7 @@ data class TrackData(
     val showDate: String,
     val artUrl: String,
     val sourceUrl: String,
-    val taperNotes: String?
+    val taperNotes: String?,
+    val set: String? = null,
+    val setName: String? = null
 )

--- a/mobile/src/main/java/com/bayapps/android/robophish/model/PhishProviderSource.kt
+++ b/mobile/src/main/java/com/bayapps/android/robophish/model/PhishProviderSource.kt
@@ -74,7 +74,9 @@ class PhishProviderSource(
                             showDate = show.date.toSimpleFormat(),
                             artUrl = artUrl,
                             sourceUrl = mp3Url.toString(),
-                            taperNotes = show.taper_notes
+                            taperNotes = show.taper_notes,
+                            set = track.set,
+                            setName = track.setName
                         )
                     }
                 }

--- a/mobile/src/main/res/layout/show_track_header_item.xml
+++ b/mobile/src/main/res/layout/show_track_header_item.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.material.card.MaterialCardView xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:layout_marginStart="@dimen/show_set_header_horizontal_margin"
+    android:layout_marginEnd="@dimen/show_set_header_horizontal_margin"
+    android:layout_marginTop="@dimen/show_set_header_vertical_margin"
+    android:layout_marginBottom="@dimen/show_set_header_vertical_margin"
+    app:cardBackgroundColor="@color/contentBackground"
+    app:cardCornerRadius="@dimen/show_set_header_corner_radius"
+    app:cardElevation="@dimen/show_set_header_elevation"
+    app:strokeColor="@color/bt_accent"
+    app:strokeWidth="@dimen/show_set_header_stroke_width">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:padding="@dimen/show_set_header_padding">
+
+        <View
+            android:layout_width="@dimen/show_set_header_accent_width"
+            android:layout_height="match_parent"
+            android:background="@color/bt_accent" />
+
+        <TextView
+            android:id="@+id/set_header_title"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="@dimen/show_set_header_title_margin_start"
+            android:layout_gravity="center_vertical"
+            android:textAppearance="?android:attr/textAppearanceMedium"
+            android:textColor="@color/primaryTextColor"
+            android:textStyle="bold" />
+
+    </LinearLayout>
+
+</com.google.android.material.card.MaterialCardView>

--- a/mobile/src/main/res/values/dimens.xml
+++ b/mobile/src/main/res/values/dimens.xml
@@ -33,6 +33,16 @@
     <dimen name="media_item_height">72dp</dimen>
     <dimen name="media_item_icon_margin_start">12dp</dimen>
     <dimen name="media_item_text_margin_start">60dp</dimen>
+
+    <!-- show set headers -->
+    <dimen name="show_set_header_horizontal_margin">12dp</dimen>
+    <dimen name="show_set_header_vertical_margin">8dp</dimen>
+    <dimen name="show_set_header_corner_radius">12dp</dimen>
+    <dimen name="show_set_header_elevation">2dp</dimen>
+    <dimen name="show_set_header_stroke_width">1dp</dimen>
+    <dimen name="show_set_header_padding">12dp</dimen>
+    <dimen name="show_set_header_accent_width">4dp</dimen>
+    <dimen name="show_set_header_title_margin_start">12dp</dimen>
     <!-- Margins for the ShowcaseView button -->
     <dimen name="button_margin">50dp</dimen>
 

--- a/networking/src/main/kotlin/robophish/model/Track.kt
+++ b/networking/src/main/kotlin/robophish/model/Track.kt
@@ -1,5 +1,6 @@
 package robophish.model
 
+import com.squareup.moshi.Json
 import com.squareup.moshi.JsonClass
 import okhttp3.HttpUrl
 import java.util.concurrent.TimeUnit
@@ -9,7 +10,9 @@ data class Track(
         val id: String,
         val title: String,
         val mp3: HttpUrl?,
-        val duration: Long
+        val duration: Long,
+        val set: String? = null,
+        @Json(name = "set_name") val setName: String? = null
 ) {
     val formatedDuration: String get() {
         return String.format("%d:%02d",


### PR DESCRIPTION
### Motivation

- Improve the show "Tracks" view by grouping songs into discrete, visually distinct sections (Set 1, Set 2, Encore, etc.) using existing set metadata from the API.
- Surface set/set-name metadata through the data pipeline so the UI can determine set boundaries.

### Description

- Propagate set metadata from the network model into app models by adding `set` and `set_name` to `robophish.model.Track` and corresponding fields to `TrackData` in `MusicProviderSource` and `PhishProviderSource`.
- Attach set metadata to `MediaItem` via `MediaMetadata.extras` in `MusicProvider.toTrackMediaItem()` using `EXTRA_TRACK_SET` and `EXTRA_TRACK_SET_NAME` so downstream UI can read it.
- Implement a `SectionedTracksAdapter` in `MediaBrowserFragment` to build a combined list of header rows and track rows, resolve readable set labels (e.g. "Set 1", "Encore"), and render styled set header views; wire this adapter into the show tracks page and update selection/restore logic and playback-state refreshes to support the new adapter.
- Add a new layout `show_track_header_item.xml` and supporting dimension resources in `values/dimens.xml` to style the set headers.

### Testing

- No automated tests were run in this change set (no unit or instrumentation tests executed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972ad7cd53483319c7fe5e37d90fe12)